### PR TITLE
Hardcode swap chain format to Bgra8Unorm

### DIFF
--- a/src/ui/backend/mod.rs
+++ b/src/ui/backend/mod.rs
@@ -249,7 +249,7 @@ fn render_thread<E, R>(
     ]);
 
     // Create and initialize our renderer with a Vulkan surface.
-    let mut renderer = render::Renderer::new(&instance, &surface, &mut imgui).unwrap();
+    let mut renderer = render::Renderer::new(&instance, &mut imgui).unwrap();
 
     let mut target = render::Target::new(surface);
 

--- a/src/ui/backend/render.rs
+++ b/src/ui/backend/render.rs
@@ -7,7 +7,6 @@ use std::{
 use anyhow::{Result, anyhow};
 use encase::ShaderType;
 use imgui::{DrawData, DrawIdx, FontAtlasFlags, TextureId, internal::RawWrapper};
-use itertools::Itertools;
 use zerocopy::IntoBytes;
 
 /// The renderer structure.
@@ -389,25 +388,15 @@ impl Renderer {
     }
 
     /// Initializes all rendering resources.
-    pub fn new(
-        instance: &wgpu::Instance,
-        surface: &wgpu::Surface,
-        imgui: &mut imgui::Context,
-    ) -> Result<Self> {
+    pub fn new(instance: &wgpu::Instance, imgui: &mut imgui::Context) -> Result<Self> {
         let runtime = tokio::runtime::Builder::new_current_thread().build()?;
         let adapter = runtime.block_on(instance.request_adapter(&Default::default()))?;
         let (device, queue) = runtime.block_on(adapter.request_device(&Default::default()))?;
 
         // Choose a surface format.
-        let surface_caps = surface.get_capabilities(&adapter);
-        let surface_format = *surface_caps
-            .formats
-            .iter()
-            .find_or_first(|f| !f.is_srgb())
-            .unwrap();
         let surface_config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format: surface_format,
+            format: wgpu::TextureFormat::Bgra8Unorm,
             width: 0,
             height: 0,
             present_mode: wgpu::PresentMode::AutoVsync,


### PR DESCRIPTION
hello

I had some issues making mvi work on my computer (Linux, AMD gpu), like:

    Caused by:
      In Device::create_render_pipeline
        Features Features { features_wgpu: FeaturesWGPU(TEXTURE_FORMAT_16BIT_NORM), features_webgpu: FeaturesWebGPU(0x0) } are required but not enabled on the device

then after changing the `adapter.request_device` call to enable the missing feature:

    wgpu error: Validation Error
    Caused by:
      In Device::create_render_pipeline
        Color state [0] is invalid
          Format Rgba16Unorm is not renderable

It doesn't seem mvi relies on the texture format for anything, and from the docs this is one of the formats that are guaranteed to work: https://docs.rs/wgpu/28.0.0/wgpu/type.SurfaceConfiguration.html#structfield.format

there is still a segfault when `EventHandler` drops is `backend::run` when i close the window. It doesn't segfault if i Ctrl-C. I don't know if the issue is present in master