### PR TITLE
Ram watch expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +1843,7 @@ dependencies = [
  "libloading 0.9.0",
  "libretro-ffi",
  "nom",
+ "nom_locate",
  "reqwest",
  "rfd",
  "rubato",
@@ -1920,6 +1927,17 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "itertools 0.14.0",
  "libloading 0.9.0",
  "libretro-ffi",
+ "nom",
  "reqwest",
  "rfd",
  "rubato",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ itertools = "0.14.0"
 libloading = "0.9.0"
 libretro-ffi = { version = "0.1.0", path = "libretro-ffi" }
 nom = "7.1.3"
+nom_locate = "4.2.0"
 reqwest = "0.13.1"
 rfd = "0.17.1"
 rubato = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.14.0"
 
 libloading = "0.9.0"
 libretro-ffi = { version = "0.1.0", path = "libretro-ffi" }
+nom = "7.1.3"
 reqwest = "0.13.1"
 rfd = "0.17.1"
 rubato = "1.0.0"

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,0 +1,636 @@
+use anyhow::Context;
+use nom::{
+    IResult,
+    branch::alt,
+    bytes::complete::{escaped_transform, tag},
+    character::complete::{hex_digit1, multispace0, none_of, one_of},
+    combinator::{map, map_res, opt, value},
+    multi::fold_many0,
+    number::complete::double,
+    sequence::{delimited, pair},
+};
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+
+/// Complex memory watch expression
+///
+/// The expression is executed using a stack and is serialized as a list of operators that interact
+/// with this stack.
+///
+/// # Syntax
+///
+/// The expression is parsed using a language similar to mesen's. See [`StackOperation`]s for
+/// operator syntax.
+///
+/// Number format:
+/// - `1234` is decimal
+/// - `$1234` or `0x1234` is hexadecimal
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct Expression {
+    /// The expression represented in Reverse Polish notation
+    operations: Vec<StackOperation>,
+
+    /// The original text form of the expression
+    raw: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+enum StackOperation {
+    /// Syntax: `a & b`
+    /// Pops two integers from the stack, performs bitwise AND, then pushes the result back
+    BitwiseAnd,
+
+    /// Syntax: `~a` or `!a`
+    /// Pops one integer from the stack, performs bitwise NOT, then pushes the result back
+    BitwiseNot,
+
+    /// Syntax: `a | b`
+    /// Pops two integers from the stack, performs bitwise OR, then pushes the result back
+    BitwiseOr,
+
+    /// Syntax: `a << b`
+    /// Pops two integers from the stack, performs arithmetic left shift, then pushes the result back
+    /// The second operand (first one to be poped from the stack) must be positive and fit in `u32`
+    BitwiseShiftLeft,
+
+    /// Syntax: `a >> b`
+    /// Pops two integers from the stack, performs arithmetic right shift, then pushes the result back
+    /// The second operand (first one to be popped from the stack) must be positive and fit in `u32`
+    BitwiseShiftRight,
+
+    /// Syntax: `a ^ b`
+    /// Pops two integers from the stack, performs bitwise XOR, then pushes the result back
+    BitwiseXor,
+
+    /// Syntax: `a / b`
+    /// Pops two numbers from the stack, divides them, then pushes the result back
+    /// If both numbers are integers, integer division is performed. In this case, the second
+    /// operand (first one to be popped from the stack) must not be zero.
+    /// If one of the numbers are floats, both are cast to floats and floating point division is
+    /// performed. In this case, both operands cannot be zero.
+    Divide,
+
+    /// Syntax: `[a]`
+    /// Pops an integer from the stack, uses it as an address to read 1 byte from memory, then
+    /// pushes the value back.
+    /// The integer must fit in `u32`.
+    Fetch1Byte,
+
+    /// Syntax: `{a}`
+    /// Pops an integer from the stack, uses it as an address to read 2 bytes from memory, then
+    /// pushes the value back.
+    /// The integer must fit in `u32`.
+    Fetch2Bytes,
+
+    /// Syntax: `#a`
+    /// Pops an integer from the stack, uses it as an address to read 4 bytes from memory, then
+    /// pushes the value back.
+    /// The integer must fit in `u32`.
+    Fetch4Bytes,
+
+    // TODO doc
+    LogicalAnd,
+    LogicalOr,
+    Minus,
+    Modulo,
+    Multiply,
+    Plus,
+    PushFloat(f64),
+    PushInteger(i64),
+    PushString(String),
+    TestEqual,
+    TestLowerEqual,
+    TestLowerStrict,
+    TestGreaterEqual,
+    TestGreaterStrict,
+    TestUnequal,
+    UnaryNegation,
+}
+
+enum StackValue<'a> {
+    Integer(i64),
+    Float(f64),
+    String(&'a str),
+}
+
+pub enum ExecutionLog {
+    // TODO
+}
+
+impl FromStr for Expression {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl fmt::Display for Expression {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.raw, f)
+    }
+}
+
+impl Expression {
+    fn parse(s: &str) -> anyhow::Result<Self> {
+        fn quoted_string(s: &str) -> IResult<&str, Vec<StackOperation>> {
+            let (s, quoted) = delimited(
+                tag("'"),
+                escaped_transform(
+                    none_of("\\'"),
+                    '\\',
+                    alt((value("\\", tag("\\")), value("'", tag("'")))),
+                ),
+                tag("'"),
+            )(s)?;
+            Ok((s, vec![StackOperation::PushString(quoted)]))
+        }
+
+        fn double_quoted_string(s: &str) -> IResult<&str, Vec<StackOperation>> {
+            let (s, quoted) = delimited(
+                tag("\""),
+                escaped_transform(
+                    none_of("\\\""),
+                    '\\',
+                    alt((value("\\", tag("\\")), value("\"", tag("\"")))),
+                ),
+                tag("\""),
+            )(s)?;
+            Ok((s, vec![StackOperation::PushString(quoted)]))
+        }
+
+        fn term(s: &str) -> IResult<&str, Vec<StackOperation>> {
+            delimited(
+                multispace0,
+                alt((
+                    delimited(tag("("), binary_operators(BINARY_OPERATORS), tag(")")),
+                    map(
+                        delimited(tag("["), binary_operators(BINARY_OPERATORS), tag("]")),
+                        |mut rpn| {
+                            rpn.push(StackOperation::Fetch1Byte);
+                            rpn
+                        },
+                    ),
+                    map(
+                        delimited(tag("{"), binary_operators(BINARY_OPERATORS), tag("}")),
+                        |mut rpn| {
+                            rpn.push(StackOperation::Fetch2Bytes);
+                            rpn
+                        },
+                    ),
+                    map_res(
+                        pair(opt(alt((tag("0x"), tag("$")))), hex_digit1),
+                        |(hex_prefix, digits)| {
+                            let radix = if hex_prefix.is_some() { 16 } else { 10 };
+                            i64::from_str_radix(digits, radix)
+                                .map(|i| vec![StackOperation::PushInteger(i)])
+                        },
+                    ),
+                    map(double, |f| vec![StackOperation::PushFloat(f)]),
+                    quoted_string,
+                    double_quoted_string,
+                    // If() and functions...
+                )),
+                multispace0,
+            )(s)
+        }
+
+        fn unary_operators(s: &str) -> IResult<&str, Vec<StackOperation>> {
+            map(pair(opt(one_of("-~#")), term), |(op, mut rpn)| {
+                match op {
+                    Some('-') => rpn.push(StackOperation::UnaryNegation),
+                    Some('~') => rpn.push(StackOperation::BitwiseNot),
+                    Some('#') => rpn.push(StackOperation::Fetch4Bytes),
+                    Some(_) => unreachable!(),
+                    None => {}
+                }
+                rpn
+            })(s)
+        }
+
+        /// binary operators ordered by precedence.
+        /// operators at lower indices have lower precedence
+        const BINARY_OPERATORS: &[&[&str]] = &[
+            &["||"],
+            &["&&"],
+            &["==", "!=", "<=", ">=", "<", ">"],
+            &["|"],
+            &["^"],
+            &["&"],
+            &["<<", ">>"],
+            &["+", "-"],
+            &["*", "/", "%"],
+        ];
+
+        fn binary_operator(ops: &[&str]) -> impl FnMut(&str) -> IResult<&str, &str> {
+            |s: &str| match *ops {
+                [a] => alt((tag(a),))(s),
+                [a, b] => alt((tag(a), tag(b)))(s),
+                [a, b, c] => alt((tag(a), tag(b), tag(c)))(s),
+                [a, b, c, d, e, f] => alt((tag(a), tag(b), tag(c), tag(d), tag(e), tag(f)))(s),
+                _ => unreachable!(),
+            }
+        }
+
+        fn binary_operators(
+            binops: &[&[&str]],
+        ) -> impl FnMut(&str) -> IResult<&str, Vec<StackOperation>> {
+            |s: &str| -> IResult<&str, Vec<StackOperation>> {
+                let Some((low_precedence_binops, binops)) = binops.split_first() else {
+                    return unary_operators(s);
+                };
+                let (s, init) = binary_operators(binops)(s)?;
+                fold_many0(
+                    pair(
+                        binary_operator(low_precedence_binops),
+                        binary_operators(binops),
+                    ),
+                    move || init.clone(),
+                    |mut acc, (op, term)| {
+                        acc.extend(term);
+                        match op {
+                            "||" => acc.push(StackOperation::LogicalOr),
+                            "&&" => acc.push(StackOperation::LogicalAnd),
+                            "==" => acc.push(StackOperation::TestEqual),
+                            "!=" => acc.push(StackOperation::TestUnequal),
+                            "<=" => acc.push(StackOperation::TestLowerEqual),
+                            ">=" => acc.push(StackOperation::TestGreaterEqual),
+                            "<" => acc.push(StackOperation::TestLowerStrict),
+                            ">" => acc.push(StackOperation::TestGreaterStrict),
+                            "|" => acc.push(StackOperation::BitwiseOr),
+                            "^" => acc.push(StackOperation::BitwiseXor),
+                            "&" => acc.push(StackOperation::BitwiseAnd),
+                            "<<" => acc.push(StackOperation::BitwiseShiftLeft),
+                            ">>" => acc.push(StackOperation::BitwiseShiftRight),
+                            "+" => acc.push(StackOperation::Plus),
+                            "-" => acc.push(StackOperation::Minus),
+                            "*" => acc.push(StackOperation::Multiply),
+                            "/" => acc.push(StackOperation::Divide),
+                            "%" => acc.push(StackOperation::Modulo),
+                            _ => unreachable!(),
+                        }
+                        acc
+                    },
+                )(s)
+            }
+        }
+
+        fn segments(s: &str) -> IResult<&str, Vec<StackOperation>> {
+            fold_many0(
+                binary_operators(BINARY_OPERATORS),
+                Vec::new,
+                |mut acc, term| {
+                    acc.extend(term);
+                    acc
+                },
+            )(s)
+        }
+
+        let tokens = match segments(s) {
+            Ok((rest, tokens)) => {
+                if !rest.is_empty() {
+                    anyhow::bail!("junk {rest:?} at the end");
+                }
+                tokens
+            }
+            Err(err) => anyhow::bail!("parsing failed: {err}"),
+        };
+
+        Ok(Self {
+            operations: tokens,
+            raw: s.to_string(),
+        })
+    }
+
+    /// `read_memory` takes an address and returns the byte at that address
+    pub fn execute<F>(&self, mut read_memory: F) -> anyhow::Result<String>
+    where
+        F: FnMut(usize) -> Option<u8>,
+    {
+        let mut stack = Vec::new();
+        for operation in &self.operations {
+            operation.execute(&mut stack, &mut read_memory)?;
+        }
+
+        let mut result = String::new();
+        for token in stack {
+            use std::fmt::Write;
+
+            match token {
+                StackValue::Integer(i) => {
+                    let _ = write!(&mut result, "{i}");
+                }
+                StackValue::Float(f) => {
+                    let _ = write!(&mut result, "{f}");
+                }
+                StackValue::String(s) => result.push_str(s),
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+pub fn read_memory_many<F>(address: usize, width: u8, mut read_memory: F) -> anyhow::Result<u64>
+where
+    F: FnMut(usize) -> Option<u8>,
+{
+    let mut result = 0;
+    for offset in 0..width as usize {
+        let address = address + offset;
+        let memory_value =
+            read_memory(address).with_context(|| format!("out of bounds read at {address}"))?;
+        result |= (memory_value as u64) << (offset * 8);
+    }
+    Ok(result)
+}
+
+impl StackOperation {
+    fn execute<'a, F>(
+        &'a self,
+        stack: &mut Vec<StackValue<'a>>,
+        read_memory: F,
+    ) -> anyhow::Result<()>
+    where
+        F: FnMut(usize) -> Option<u8>,
+    {
+        fn single_int_op<F>(stack: &mut Vec<StackValue<'_>>, op: F) -> anyhow::Result<()>
+        where
+            F: FnOnce(i64) -> anyhow::Result<i64>,
+        {
+            let Some(StackValue::Integer(i)) = stack.last_mut() else {
+                unreachable!()
+            };
+            *i = op(*i)?;
+            Ok(())
+        }
+
+        fn double_int_op<F>(stack: &mut Vec<StackValue<'_>>, op: F) -> anyhow::Result<()>
+        where
+            F: FnOnce(i64, i64) -> anyhow::Result<i64>,
+        {
+            let Some(StackValue::Integer(j)) = stack.pop() else {
+                unreachable!()
+            };
+            let Some(StackValue::Integer(i)) = stack.last_mut() else {
+                unreachable!()
+            };
+            *i = op(*i, j)?;
+            Ok(())
+        }
+
+        fn double_float_op<F, G>(
+            stack: &mut Vec<StackValue<'_>>,
+            op_int: F,
+            op_float: G,
+        ) -> anyhow::Result<()>
+        where
+            F: FnOnce(i64, i64) -> anyhow::Result<i64>,
+            G: FnOnce(f64, f64) -> anyhow::Result<f64>,
+        {
+            let j = stack.pop().unwrap();
+            let i = stack.pop().unwrap();
+            let op_result = match (i, j) {
+                (StackValue::Integer(i), StackValue::Integer(j)) => {
+                    StackValue::Integer(op_int(i, j)?)
+                }
+                (StackValue::Integer(i), StackValue::Float(j)) => {
+                    StackValue::Float(op_float(i as f64, j)?)
+                }
+                (StackValue::Float(i), StackValue::Integer(j)) => {
+                    StackValue::Float(op_float(i, j as f64)?)
+                }
+                (StackValue::Float(i), StackValue::Float(j)) => StackValue::Float(op_float(i, j)?),
+                _ => unreachable!(),
+            };
+            stack.push(op_result);
+            Ok(())
+        }
+
+        fn test<F, G>(stack: &mut Vec<StackValue<'_>>, test_int: F, test_float: G)
+        where
+            F: FnOnce(i64, i64) -> bool,
+            G: FnOnce(f64, f64) -> bool,
+        {
+            let j = stack.pop().unwrap();
+            let i = stack.pop().unwrap();
+            let test_result = match (i, j) {
+                (StackValue::Integer(i), StackValue::Integer(j)) => test_int(i, j),
+                (StackValue::Integer(i), StackValue::Float(j)) => test_float(i as f64, j),
+                (StackValue::Float(i), StackValue::Integer(j)) => test_float(i, j as f64),
+                (StackValue::Float(i), StackValue::Float(j)) => test_float(i, j),
+                _ => unreachable!(),
+            };
+            stack.push(StackValue::Integer(i64::from(test_result)));
+        }
+
+        match self {
+            Self::BitwiseAnd => double_int_op(stack, |i, j| Ok(i & j))?,
+            Self::BitwiseNot => single_int_op(stack, |i| Ok(!i))?,
+            Self::BitwiseOr => double_int_op(stack, |i, j| Ok(i | j))?,
+            Self::BitwiseShiftLeft => double_int_op(stack, |i, j| {
+                u32::try_from(j)
+                    .ok()
+                    .and_then(|j| i64::checked_shl(i, j))
+                    .with_context(|| format!("overflow during left shift of {i} << {j}"))
+            })?,
+            Self::BitwiseShiftRight => double_int_op(stack, |i, j| {
+                u32::try_from(j)
+                    .ok()
+                    .and_then(|j| i64::checked_shr(i, j))
+                    .with_context(|| format!("overflow during right shift of {i} >> {j}"))
+            })?,
+            Self::BitwiseXor => double_int_op(stack, |i, j| Ok(i ^ j))?,
+            Self::Divide => double_float_op(
+                stack,
+                |i, j| i64::checked_div(i, j).with_context(|| format!("divided {i} by zero")),
+                |f, g| {
+                    let x = f / g;
+                    if x.is_nan() {
+                        anyhow::bail!("tried to divide {f} by {g}");
+                    }
+                    Ok(x)
+                },
+            )?,
+            Self::Fetch1Byte | Self::Fetch2Bytes | Self::Fetch4Bytes => {
+                let width = match self {
+                    Self::Fetch1Byte => 1,
+                    Self::Fetch2Bytes => 2,
+                    Self::Fetch4Bytes => 4,
+                    _ => unreachable!(),
+                };
+                single_int_op(stack, |i| {
+                    let address =
+                        usize::try_from(i).with_context(|| format!("out-of-bounds read at {i}"))?;
+                    let value = read_memory_many(address, width, read_memory)?;
+                    Ok(i64::try_from(value).unwrap()) // we don't read more than 4 bytes
+                })?;
+            }
+            Self::PushFloat(f) => stack.push(StackValue::Float(*f)),
+            Self::PushInteger(i) => stack.push(StackValue::Integer(*i)),
+            Self::LogicalAnd => double_int_op(stack, |i, j| Ok(i64::from(i != 0 && j != 0)))?,
+            Self::LogicalOr => double_int_op(stack, |i, j| Ok(i64::from(i != 0 || j != 0)))?,
+            Self::Minus => double_float_op(
+                stack,
+                |i, j| {
+                    i64::checked_sub(i, j)
+                        .with_context(|| format!("overflow during substraction of {i} - {j}"))
+                },
+                |f, g| Ok(f - g),
+            )?,
+            Self::Modulo => double_int_op(stack, |i, j| {
+                i64::checked_rem(i, j)
+                    .with_context(|| format!("overflow during modulo of {i} % {j}"))
+            })?,
+            Self::Multiply => double_float_op(
+                stack,
+                |i, j| {
+                    i64::checked_mul(i, j)
+                        .with_context(|| format!("overflow during multiplication of {i} * {j}"))
+                },
+                |f, g| Ok(f * g),
+            )?,
+            Self::Plus => double_float_op(
+                stack,
+                |i, j| {
+                    i64::checked_add(i, j)
+                        .with_context(|| format!("overflow during addition of {i} + {j}"))
+                },
+                |f, g| Ok(f + g),
+            )?,
+            Self::PushString(s) => stack.push(StackValue::String(s)),
+            Self::TestEqual => test(stack, |i, j| i == j, |f, g| f == g),
+            Self::TestLowerEqual => test(stack, |i, j| i <= j, |f, g| f <= g),
+            Self::TestLowerStrict => test(stack, |i, j| i < j, |f, g| f < g),
+            Self::TestGreaterEqual => test(stack, |i, j| i >= j, |f, g| f >= g),
+            Self::TestGreaterStrict => test(stack, |i, j| i > j, |f, g| f > g),
+            Self::TestUnequal => test(stack, |i, j| i != j, |f, g| f != g),
+            Self::UnaryNegation => match stack.last_mut().unwrap() {
+                StackValue::Integer(i) => {
+                    *i = i64::checked_neg(*i)
+                        .with_context(|| format!("overflow during negation of {i}"))?
+                }
+                StackValue::Float(f) => {
+                    *f = -*f;
+                }
+                _ => unreachable!(),
+            },
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse and run the expression, all memory reads return 42.
+    fn assert_expr(
+        expression: &str,
+        expected_operations: Vec<StackOperation>,
+        expected_result: &str,
+    ) {
+        let expression: Expression = expression.parse().unwrap();
+        assert_eq!(expression.operations, expected_operations);
+        let actual_result = expression.execute(|_| Some(42)).unwrap();
+        assert_eq!(&actual_result, expected_result);
+    }
+
+    #[test]
+    fn test_empty() {
+        assert_expr("", vec![], "");
+    }
+
+    #[test]
+    fn test_simple() {
+        assert_expr("1", vec![StackOperation::PushInteger(1)], "1");
+    }
+
+    #[test]
+    fn test_add() {
+        assert_expr(
+            " 1 +1",
+            vec![
+                StackOperation::PushInteger(1),
+                StackOperation::PushInteger(1),
+                StackOperation::Plus,
+            ],
+            "2",
+        );
+    }
+
+    #[test]
+    fn test_string() {
+        assert_expr(
+            " \" my string\"  \n 21*(1 + 1)\n",
+            vec![
+                StackOperation::PushString(" my string".to_owned()),
+                StackOperation::PushInteger(21),
+                StackOperation::PushInteger(1),
+                StackOperation::PushInteger(1),
+                StackOperation::Plus,
+                StackOperation::Multiply,
+            ],
+            " my string42",
+        );
+    }
+
+    #[test]
+    fn test_memory() {
+        assert_expr(
+            "'game state: ' {0x998}",
+            vec![
+                StackOperation::PushString("game state: ".to_owned()),
+                StackOperation::PushInteger(0x998),
+                StackOperation::Fetch2Bytes,
+            ],
+            &format!("game state: {}", 42 << 8 | 42),
+        );
+    }
+
+    #[test]
+    fn test_sm_jump_speed() {
+        assert_expr(
+            "'jump speed will be ' [$A1C] * {0x909eb9+2*(1+(({$9A2}&(1<<8)==0)&&({$195e}>=0)&&({$afa}+{$b00}>{$195E}))+6*({$9A2}&(1<<8)!=0))} + ({$9A2}&(1<<13)!=0)*({$B42}/2) 'px/f'",
+            vec![
+                StackOperation::PushString("jump speed will be ".to_owned()),
+                StackOperation::PushInteger(0xA1C),
+                StackOperation::Fetch1Byte,
+                StackOperation::PushInteger(0x909EB9),
+                StackOperation::PushInteger(2),
+                StackOperation::PushInteger(0x9A2),
+                StackOperation::Fetch2Bytes,
+                StackOperation::PushInteger(1),
+                StackOperation::PushInteger(8),
+                StackOperation::BitwiseShiftLeft,
+                StackOperation::BitwiseAnd,
+                StackOperation::PushInteger(0),
+                StackOperation::TestEqual,
+                StackOperation::PushInteger(0x195E),
+                StackOperation::Fetch2Bytes,
+                StackOperation::PushInteger(0),
+                StackOperation::TestGreaterEqual,
+                StackOperation::LogicalAnd,
+                // TODO
+            ],
+            "jump speed will be px/f",
+        );
+    }
+
+    #[test]
+    fn test_sm_graple_swing() {
+        assert_expr(
+            "'graple X speed will be ' 'px/f'",
+            vec![
+                StackOperation::PushString("graple X speed will be ".to_owned()),
+                // TODO
+            ],
+            "graple X speed will be px/f",
+        );
+    }
+
+    #[test]
+    fn test_invalid() {
+        assert!("[".parse::<Expression>().is_err());
+    }
+}

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -9,6 +9,7 @@ use nom::{
     number::complete::double,
     sequence::{delimited, pair},
 };
+use nom_locate::LocatedSpan;
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
@@ -121,7 +122,7 @@ impl FromStr for Expression {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::parse(s)
+        Self::parse(s.into())
     }
 }
 
@@ -131,9 +132,11 @@ impl fmt::Display for Expression {
     }
 }
 
+type Span<'a> = LocatedSpan<&'a str>;
+
 impl Expression {
-    fn parse(s: &str) -> anyhow::Result<Self> {
-        fn quoted_string(s: &str) -> IResult<&str, Vec<StackOperation>> {
+    fn parse(s: Span<'_>) -> anyhow::Result<Self> {
+        fn quoted_string(s: Span<'_>) -> IResult<Span<'_>, Vec<StackOperation>> {
             let (s, quoted) = delimited(
                 tag("'"),
                 escaped_transform(
@@ -146,7 +149,7 @@ impl Expression {
             Ok((s, vec![StackOperation::PushString(quoted)]))
         }
 
-        fn double_quoted_string(s: &str) -> IResult<&str, Vec<StackOperation>> {
+        fn double_quoted_string(s: Span<'_>) -> IResult<Span<'_>, Vec<StackOperation>> {
             let (s, quoted) = delimited(
                 tag("\""),
                 escaped_transform(
@@ -159,7 +162,7 @@ impl Expression {
             Ok((s, vec![StackOperation::PushString(quoted)]))
         }
 
-        fn term(s: &str) -> IResult<&str, Vec<StackOperation>> {
+        fn term(s: Span<'_>) -> IResult<Span<'_>, Vec<StackOperation>> {
             delimited(
                 multispace0,
                 alt((
@@ -180,9 +183,9 @@ impl Expression {
                     ),
                     map_res(
                         pair(opt(alt((tag("0x"), tag("$")))), hex_digit1),
-                        |(hex_prefix, digits)| {
+                        |(hex_prefix, digits): (Option<Span<'_>>, Span<'_>)| {
                             let radix = if hex_prefix.is_some() { 16 } else { 10 };
-                            i64::from_str_radix(digits, radix)
+                            i64::from_str_radix(*digits, radix)
                                 .map(|i| vec![StackOperation::PushInteger(i)])
                         },
                     ),
@@ -195,7 +198,7 @@ impl Expression {
             )(s)
         }
 
-        fn unary_operators(s: &str) -> IResult<&str, Vec<StackOperation>> {
+        fn unary_operators(s: Span<'_>) -> IResult<Span<'_>, Vec<StackOperation>> {
             map(pair(opt(one_of("-~#")), term), |(op, mut rpn)| {
                 match op {
                     Some('-') => rpn.push(StackOperation::UnaryNegation),
@@ -222,8 +225,8 @@ impl Expression {
             &["*", "/", "%"],
         ];
 
-        fn binary_operator(ops: &[&str]) -> impl FnMut(&str) -> IResult<&str, &str> {
-            |s: &str| match *ops {
+        fn binary_operator(ops: &[&str]) -> impl FnMut(Span<'_>) -> IResult<Span<'_>, Span<'_>> {
+            |s: Span<'_>| match *ops {
                 [a] => alt((tag(a),))(s),
                 [a, b] => alt((tag(a), tag(b)))(s),
                 [a, b, c] => alt((tag(a), tag(b), tag(c)))(s),
@@ -234,8 +237,8 @@ impl Expression {
 
         fn binary_operators(
             binops: &[&[&str]],
-        ) -> impl FnMut(&str) -> IResult<&str, Vec<StackOperation>> {
-            |s: &str| -> IResult<&str, Vec<StackOperation>> {
+        ) -> impl FnMut(Span<'_>) -> IResult<Span<'_>, Vec<StackOperation>> {
+            |s: Span<'_>| -> IResult<Span<'_>, Vec<StackOperation>> {
                 let Some((low_precedence_binops, binops)) = binops.split_first() else {
                     return unary_operators(s);
                 };
@@ -248,7 +251,7 @@ impl Expression {
                     move || init.clone(),
                     |mut acc, (op, term)| {
                         acc.extend(term);
-                        match op {
+                        match *op {
                             "||" => acc.push(StackOperation::LogicalOr),
                             "&&" => acc.push(StackOperation::LogicalAnd),
                             "==" => acc.push(StackOperation::TestEqual),
@@ -275,7 +278,7 @@ impl Expression {
             }
         }
 
-        fn segments(s: &str) -> IResult<&str, Vec<StackOperation>> {
+        fn segments(s: Span<'_>) -> IResult<Span<'_>, Vec<StackOperation>> {
             fold_many0(
                 binary_operators(BINARY_OPERATORS),
                 Vec::new,
@@ -289,7 +292,12 @@ impl Expression {
         let tokens = match segments(s) {
             Ok((rest, tokens)) => {
                 if !rest.is_empty() {
-                    anyhow::bail!("junk {rest:?} at the end");
+                    anyhow::bail!(
+                        "junk {:?} at line #{} character #{}",
+                        *rest,
+                        rest.location_line(),
+                        rest.get_utf8_column()
+                    );
                 }
                 tokens
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod core;
+mod expression;
 mod tas;
 mod ui;
 

--- a/src/tas/mod.rs
+++ b/src/tas/mod.rs
@@ -153,12 +153,11 @@ impl Tas {
         &self.movie
     }
 
-    pub fn read_ram_watch(&self, watch: &movie::RamWatch) -> Option<u64> {
-        let mut v = 0;
-        for offset in 0..watch.format.width as usize {
-            v |= (self.core.read_memory_byte(watch.address + offset)? as u64) << (offset * 8);
-        }
-        Some(v)
+    pub fn read_ram_watch(&self, watch: &movie::RamWatch) -> Option<String> {
+        watch
+            .value
+            .execute(|address| self.core.read_memory_byte(address))
+            .ok()
     }
 
     pub fn ramwatches_mut(&mut self) -> &mut Vec<movie::RamWatch> {

--- a/src/tas/movie/mod.rs
+++ b/src/tas/movie/mod.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     core,
+    expression::{Expression, read_memory_many},
     tas::edit::{Pattern, PatternBuf},
 };
 
@@ -35,8 +36,30 @@ pub struct Movie {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RamWatch {
     pub name: String,
-    pub address: usize,
-    pub format: RamWatchFormat,
+    pub value: RamWatchValue,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub enum RamWatchValue {
+    Simple {
+        address: usize,
+        format: RamWatchFormat,
+    },
+    Expression(Expression),
+}
+
+impl RamWatchValue {
+    pub fn execute<F>(&self, read_memory: F) -> anyhow::Result<String>
+    where
+        F: FnMut(usize) -> Option<u8>,
+    {
+        match self {
+            Self::Simple { address, format } => {
+                Ok(format.format_value(read_memory_many(*address, format.width, read_memory)?))
+            }
+            Self::Expression(expression) => expression.execute(read_memory),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/ui/ramwatch.rs
+++ b/src/ui/ramwatch.rs
@@ -12,8 +12,11 @@ struct Editor {
     state: EditorState,
     should_focus: bool,
     name: String,
+    /// `true` if expression must be used instead of address and format
+    use_expression: bool,
     address: String,
     format: movie::RamWatchFormat,
+    expression: String,
 }
 
 #[derive(Copy, Clone, PartialEq)]
@@ -26,8 +29,15 @@ enum EditorState {
 impl Editor {
     fn init_from_ram_watch(&mut self, watch: &movie::RamWatch) {
         self.name = watch.name.clone();
-        self.address = format!("{:#04X}", watch.address);
-        self.format = watch.format.clone();
+        match watch.value.clone() {
+            movie::RamWatchValue::Simple { address, format } => {
+                self.address = format!("{:#04X}", address);
+                self.format = format;
+            }
+            movie::RamWatchValue::Expression(expression) => {
+                self.expression = expression.to_string()
+            }
+        }
     }
 
     fn to_ram_watch(&self) -> Option<movie::RamWatch> {
@@ -35,14 +45,19 @@ impl Editor {
         if name.is_empty() {
             return None;
         }
-        let address =
-            usize::from_str_radix(self.address.strip_prefix("0x").unwrap_or(&self.address), 16)
-                .ok()?;
-        Some(movie::RamWatch {
-            name,
-            address,
-            format: self.format.clone(),
-        })
+        let value = if self.use_expression {
+            movie::RamWatchValue::Expression(self.expression.parse().ok()?)
+        } else {
+            movie::RamWatchValue::Simple {
+                address: usize::from_str_radix(
+                    self.address.strip_prefix("0x").unwrap_or(&self.address),
+                    16,
+                )
+                .ok()?,
+                format: self.format.clone(),
+            }
+        };
+        Some(movie::RamWatch { name, value })
     }
 }
 
@@ -52,12 +67,14 @@ impl Default for Editor {
             state: EditorState::Closed,
             should_focus: false,
             name: String::new(),
+            use_expression: false,
             address: String::new(),
             format: movie::RamWatchFormat {
                 width: 1,
                 hex: true,
                 signed: false,
             },
+            expression: String::new(),
         }
     }
 }
@@ -93,32 +110,57 @@ impl RamWatch {
                     }
                     ui.input_text("Name", &mut self.editor.name).build();
 
-                    ui.input_text("Address", &mut self.editor.address).build();
+                    if self.editor.use_expression {
+                        ui.input_text_multiline(
+                            "Expression",
+                            &mut self.editor.expression,
+                            ui.content_region_avail(),
+                        )
+                        .no_horizontal_scroll(true)
+                        .build();
+                    } else {
+                        ui.input_text("Address", &mut self.editor.address).build();
+
+                        let group = ui.begin_group();
+                        ui.columns(2, "ram_watch_editor", false);
+
+                        ui.text("Size");
+                        ui.radio_button("8 bits", &mut self.editor.format.width, 1);
+                        ui.radio_button("16 bits", &mut self.editor.format.width, 2);
+                        ui.radio_button("32 bits", &mut self.editor.format.width, 3);
+                        ui.radio_button("64 bits", &mut self.editor.format.width, 4);
+
+                        ui.next_column();
+
+                        ui.text("Format");
+                        ui.radio_button("Hex", &mut self.editor.format.hex, true);
+                        ui.radio_button("Decimal", &mut self.editor.format.hex, false);
+
+                        ui.checkbox("Signed", &mut self.editor.format.signed);
+                        group.end();
+                    }
 
                     let group = ui.begin_group();
-                    ui.columns(2, "ram_watch_editor", false);
+                    ui.columns(2, "ram_watch_confirm", false);
 
-                    ui.text("Size");
-                    ui.radio_button("8 bits", &mut self.editor.format.width, 1);
-                    ui.radio_button("16 bits", &mut self.editor.format.width, 2);
-                    ui.radio_button("32 bits", &mut self.editor.format.width, 3);
-                    ui.radio_button("64 bits", &mut self.editor.format.width, 4);
+                    let expression_label = if self.editor.use_expression {
+                        "Address"
+                    } else {
+                        "Expression"
+                    };
+                    if ui.button(expression_label) {
+                        self.editor.use_expression = !self.editor.use_expression;
+                    }
 
                     ui.next_column();
 
-                    ui.text("Format");
-                    ui.radio_button("Hex", &mut self.editor.format.hex, true);
-                    ui.radio_button("Decimal", &mut self.editor.format.hex, false);
-
-                    ui.checkbox("Signed", &mut self.editor.format.signed);
-                    group.end();
-
-                    ui.columns(1, "ram_watch_confirm", false);
+                    /*
                     let button_width = ui.calc_text_size("  Cancel  OK  ")[0];
                     ui.set_cursor_pos([
                         ui.window_size()[0] - button_width,
                         ui.window_size()[1] - ui.text_line_height_with_spacing() * 2.,
                     ]);
+                    // */
 
                     if ui.button("Cancel") || ui.is_key_pressed(imgui::Key::Escape) {
                         ui.close_current_popup();
@@ -141,6 +183,8 @@ impl RamWatch {
                             self.editor.state = EditorState::Closed;
                         }
                     });
+
+                    group.end();
                 }
                 _ => {
                     ui.open_popup(ADD_POPUP);
@@ -210,7 +254,7 @@ impl RamWatch {
 
                             ui.table_next_column();
                             if let Some(v) = tas.read_ram_watch(watch) {
-                                ui.text(watch.format.format_value(v));
+                                ui.text(v);
                             }
 
                             ui.table_next_column();


### PR DESCRIPTION
This allows users to enter complex expressions in the RAM watch editor, in the same fashion as lsnes or mesen

For example

Show Super Metroid game state:

    "Game state: " [$998]

Show Samus' speed:

    "vx: " {0xb46} "." {$b48}

Some other examples are available in expression tests.

Since these expressions can get pretty complicated, i was thinking maybe using lua for it would be a better idea, at the cost of discarding the concise `{address}` and `[address]` syntax (as well as `$hexnumber`). It could also be a good stepping stone to add full blown scripts to mvi